### PR TITLE
refactor: PostService 리팩토링

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/controller/PostController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/controller/PostController.java
@@ -15,6 +15,7 @@ import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.domain.post.dto.PostDto;
 import kr.inuappcenterportal.inuportal.domain.post.dto.PostListResponseDto;
 import kr.inuappcenterportal.inuportal.domain.post.dto.PostResponseDto;
+import kr.inuappcenterportal.inuportal.domain.post.service.PostImageService;
 import kr.inuappcenterportal.inuportal.domain.post.service.PostService;
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
@@ -45,6 +46,7 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
     private final RedisService redisService;
+    private final PostImageService postImageService;
 
     @Operation(summary = "게시글 등록",description = "헤더 Auth에 발급받은 토큰을, 바디에 {title,content,category,bool 형태의 anonymous} 보내주세요. 그 이후 등록된 게시글의 id와 이미지를 보내주세요. 성공 시 작성된 게시글의 데이터베이스 아이디 값이 {data: id}으로 보내집니다.")
     @ApiResponses({
@@ -67,7 +69,7 @@ public class PostController {
     @PostMapping(value = "/{postId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ResponseDto<Long>> saveOnlyImage(@RequestPart List<MultipartFile> images, @PathVariable Long postId, @AuthenticationPrincipal Member member) throws IOException {
         log.info("이미지만 저장 호출 id:{}",postId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.of(postService.saveImageLocal(member,postId,images),"이미지 등록 성공"));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.of(postImageService.saveImageLocal(member,postId,images),"이미지 등록 성공"));
     }
 
     @Operation(summary = "게시글 수정",description = "헤더 Auth에 발급받은 토큰을, url 파라미터에 게시글의 id, 바디에 {title,content,category, bool 형태의 anonymous}을 형식으로 보내주세요. 성공 시 수정된 게시글의 데이터베이스 아이디 값이 {data: id}으로 보내집니다.")
@@ -95,7 +97,7 @@ public class PostController {
         if(images==null){
             images = new ArrayList<>();
         }
-        postService.updateImageLocal(member.getId(),postId,images);
+        postImageService.updateImageLocal(member.getId(),postId,images);
         return ResponseEntity.ok(ResponseDto.of(postId,"게시글 수정 성공"));
     }
 
@@ -168,7 +170,7 @@ public class PostController {
         log.info("게시글의 이미지 가져오기 호출 id:{}",postId);
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.IMAGE_PNG);
-        return ResponseEntity.ok().headers(httpHeaders).body(postService.getImage(postId, imageId));
+        return ResponseEntity.ok().headers(httpHeaders).body(postImageService.getImage(postId, imageId));
     }
 
     @Operation(summary = "상단부 인기 게시글 12개 가져오기",description = "기본 호출 시 모든 글에 대한 인기 게시글 12개, 파라미터로 category를 보낼 시 카테고리의 인기글 12개가 호출됩니다.")

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/controller/PostController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/controller/PostController.java
@@ -46,7 +46,6 @@ public class PostController {
     private final PostService postService;
     private final RedisService redisService;
 
-
     @Operation(summary = "게시글 등록",description = "헤더 Auth에 발급받은 토큰을, 바디에 {title,content,category,bool 형태의 anonymous} 보내주세요. 그 이후 등록된 게시글의 id와 이미지를 보내주세요. 성공 시 작성된 게시글의 데이터베이스 아이디 값이 {data: id}으로 보내집니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201",description = "게시글 등록 성공",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
@@ -60,17 +59,16 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.of(postId,"게시글 등록 성공"));
     }
 
-    @Operation(summary = "이미지 등록",description = "파라미터에 게시글의 id, images에 이미지 파일들을 보내주세요. 성공 시 게시글의 데이터베이 아이디값이 {data: id}으로 보내집니다.")
+    @Operation(summary = "이미지 등록",description = "파라미터에 게시글의 id, images에 이미지 파일들을 보내주세요. 성공 시 게시글의 데이터베이스 아이디값이 {data: id}으로 보내집니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201",description = "이미지 등록 성공",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
             ,@ApiResponse(responseCode = "404",description = "존재하지 않는 게시글입니다. / 존재하지 않는 회원입니다.",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
     })
     @PostMapping(value = "/{postId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResponseDto<Long>> saveOnlyImage( @RequestPart List<MultipartFile> images,@PathVariable Long postId, @AuthenticationPrincipal Member member) throws IOException {
+    public ResponseEntity<ResponseDto<Long>> saveOnlyImage(@RequestPart List<MultipartFile> images, @PathVariable Long postId, @AuthenticationPrincipal Member member) throws IOException {
         log.info("이미지만 저장 호출 id:{}",postId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.of(postService.saveImageLocal(member,postId,images),"이미지 등록 성공"));
     }
-
 
     @Operation(summary = "게시글 수정",description = "헤더 Auth에 발급받은 토큰을, url 파라미터에 게시글의 id, 바디에 {title,content,category, bool 형태의 anonymous}을 형식으로 보내주세요. 성공 시 수정된 게시글의 데이터베이스 아이디 값이 {data: id}으로 보내집니다.")
     @ApiResponses({
@@ -84,6 +82,7 @@ public class PostController {
         postService.updateOnlyPost(member.getId(),postId,postDto);
         return ResponseEntity.ok(ResponseDto.of(postId,"게시글 수정 성공"));
     }
+
     @Operation(summary = "게시글의 이미지 수정",description = "헤더 Auth에 발급받은 토큰을, url 파라미터에 게시글의 id, images 에 기존 이미지를 포함한 이미지들을 보내주세요.(아무 이미지도 보내지 않을 시 모든 이미지가 삭제됩니다) 성공 시 수정된 게시글의 데이터베이스 아이디 값이 {data: id}으로 보내집니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200",description = "게시글이미지 수정 성공",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
@@ -111,7 +110,6 @@ public class PostController {
         log.info("게시글 삭제 호출 id:{}",postId);
         postService.delete(member.getId(),postId);
         return ResponseEntity.ok(ResponseDto.of(postId,"게시글 삭제 성공"));
-
     }
 
     @Operation(summary = "게시글 가져오기",description = "로그인 한 상태면 헤더에 Auth에 발급받은 토큰을 담아서 url 파라미터에 게시글의 id를 보내주세요.")
@@ -138,7 +136,6 @@ public class PostController {
         return ResponseEntity.ok(ResponseDto.of(postService.likePost(member,postId),"게시글 좋아요 여부 변경성공"));
     }
 
-
     @Operation(summary = "스크랩 여부 변경",description = "헤더 Auth에 발급받은 토큰을, url 파라미터에 게시글의 id를 보내주세요. 스크랩 시 {data:1}, 스크랩 해제 시 {data:-1} 입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200",description = "게시글 스크랩 성공",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
@@ -160,7 +157,6 @@ public class PostController {
             ,@RequestParam(required = false,defaultValue = "1") @Min(1) int page ){
         return ResponseEntity.ok(ResponseDto.of(postService.getAllPost(category, sort,page),"모든 게시글 가져오기 성공"));
     }
-
 
     @Operation(summary = "게시글의 이미지 가져오기",description = "url 파라미터에 postId, imageId를 보내주세요. imageId는 이미지의 등록 순번입니다.")
     @ApiResponses({

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostCommonService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostCommonService.java
@@ -1,0 +1,25 @@
+package kr.inuappcenterportal.inuportal.domain.post.service;
+
+import kr.inuappcenterportal.inuportal.domain.post.model.Post;
+import kr.inuappcenterportal.inuportal.domain.post.repository.PostRepository;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostCommonService {
+
+    private final PostRepository postRepository;
+
+    Post findPostByIdOrThrow(Long postId) {
+        return postRepository.findById(postId).orElseThrow(() -> new MyException(MyErrorCode.POST_NOT_FOUND));
+    }
+
+    void validateMemberAuthorization(Post post, Long memberId) {
+        if (!post.getMember().getId().equals(memberId)) {
+            throw new MyException(MyErrorCode.HAS_NOT_POST_AUTHORIZATION);
+        }
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostImageService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostImageService.java
@@ -1,0 +1,69 @@
+package kr.inuappcenterportal.inuportal.domain.post.service;
+
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.post.model.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostImageService {
+
+    private final PostCommonService postCommonService;
+
+    @Value("${imagePath}")
+    private String path;
+
+    @Transactional
+    public Long saveImageLocal(Member member, Long postId, List<MultipartFile> images) throws IOException {
+        Post post = postCommonService.findPostByIdOrThrow(postId);
+        postCommonService.validateMemberAuthorization(post, member.getId());
+        long imageCount = images.size();
+        post.updateImageCount(imageCount);
+        saveNewImages(postId, images);
+        return postId;
+    }
+
+    public byte[] getImage(Long postId, Long imageId) throws IOException {
+        String fileName = postId + "-" + imageId;
+        Path filePath = Paths.get(path, fileName);
+        return Files.readAllBytes(filePath);
+    }
+
+    @Transactional
+    public void updateImageLocal(Long memberId, Long postId, List<MultipartFile> images) throws IOException {
+        Post post = postCommonService.findPostByIdOrThrow(postId);
+        postCommonService.validateMemberAuthorization(post, memberId);
+        if (images != null) {
+            deleteExistingImages(postId, post.getImageCount());
+            saveNewImages(postId, images);
+            post.updateImageCount(images.size());
+        }
+    }
+
+    public void saveNewImages(Long postId, List<MultipartFile> images) throws IOException {
+        for (int i = 0; i < images.size(); i++) {
+            MultipartFile file = images.get(i);
+            String fileName = postId + "-" + (i + 1);
+            Path filePath = Paths.get(path, fileName);
+            Files.write(filePath, file.getBytes());
+        }
+    }
+
+    public void deleteExistingImages(Long postId, long imageCount) throws IOException {
+        for (int i = 1; i <= imageCount; i++) {
+            String fileName = postId + "-" + i;
+            Path filePath = Paths.get(path, fileName);
+            Files.deleteIfExists(filePath);
+        }
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
@@ -50,26 +50,34 @@ public class PostService {
     @Value("${imagePath}")
     private String path;
 
-
     @Transactional
     public Long saveOnlyPost(Member member, PostDto postSaveDto) throws NoSuchAlgorithmException {
-        if(!categoryRepository.existsByCategory(postSaveDto.getCategory())){
-            throw new MyException(MyErrorCode.CATEGORY_NOT_FOUND);
-        }
-        String hash = postSaveDto.getTitle()+postSaveDto.getContent();
+        validateCategory(postSaveDto);
+        String hash = postSaveDto.getTitle() + postSaveDto.getContent();
         redisService.blockRepeat(hash);
-        Post post = Post.builder().title(postSaveDto.getTitle()).content(postSaveDto.getContent()).anonymous(postSaveDto.getAnonymous()).category(postSaveDto.getCategory()).member(member).imageCount(0).build();
+        Post post = Post.builder()
+                .title(postSaveDto.getTitle())
+                .content(postSaveDto.getContent())
+                .anonymous(postSaveDto.getAnonymous())
+                .category(postSaveDto.getCategory())
+                .member(member)
+                .imageCount(0)
+                .build();
         postRepository.save(post);
         return post.getId();
     }
 
+    private void validateCategory(PostDto postSaveDto) {
+        if (!categoryRepository.existsByCategory(postSaveDto.getCategory())) {
+            throw new MyException(MyErrorCode.CATEGORY_NOT_FOUND);
+        }
+    }
 
     @Transactional
-    public Long saveImageLocal(Member member, Long postId, List<MultipartFile> images ) throws IOException {
-        Post post = postRepository.findById(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(!post.getMember().getId().equals(member.getId())){
-            throw new MyException(MyErrorCode.HAS_NOT_POST_AUTHORIZATION);
-        }
+    public Long saveImageLocal(Member member, Long postId, List<MultipartFile> images) throws IOException {
+        Post post = findPostByIdOrThrow(postId);
+
+        validateMemberAuthorization(post, member.getId());
         long imageCount;
         if (images != null) {
             imageCount = images.size();
@@ -84,38 +92,45 @@ public class PostService {
         return postId;
     }
 
+    private Post findPostByIdOrThrow(Long postId) {
+        return postRepository.findById(postId).orElseThrow(() -> new MyException(MyErrorCode.POST_NOT_FOUND));
+    }
+
+    private static void validateMemberAuthorization(Post post, Long memberId) {
+        if (!post.getMember().getId().equals(memberId)) {
+            throw new MyException(MyErrorCode.HAS_NOT_POST_AUTHORIZATION);
+        }
+    }
+
     public byte[] getImage(Long postId, Long imageId) throws IOException {
-        String fileName = postId+"-"+imageId;
+        String fileName = postId + "-" + imageId;
         Path filePath = Paths.get(path, fileName);
         return Files.readAllBytes(filePath);
     }
 
     @Transactional
-    public void updateOnlyPost(Long memberId, Long postId, PostDto postDto){
-        Post post = postRepository.findById(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(!categoryRepository.existsByCategory(postDto.getCategory())){
-            throw new MyException(MyErrorCode.CATEGORY_NOT_FOUND);
-        }
-        if(!post.getMember().getId().equals(memberId)){
+    public void updateOnlyPost(Long memberId, Long postId, PostDto postDto) {
+        Post post = findPostByIdOrThrow(postId);
+        validateCategory(postDto);
+        if (!post.getMember().getId().equals(memberId)) {
             throw new MyException(MyErrorCode.HAS_NOT_POST_AUTHORIZATION);
         }
-        post.updateOnlyPost(postDto.getTitle(),postDto.getContent(), postDto.getCategory(),postDto.getAnonymous());
+        post.updateOnlyPost(postDto.getTitle(), postDto.getContent(), postDto.getCategory(), postDto.getAnonymous());
     }
 
-
     @Transactional
-    public void updateImageLocal(Long memberId, Long postId, List<MultipartFile> images) throws IOException{
-        Post post = postRepository.findById(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(!post.getMember().getId().equals(memberId)){
+    public void updateImageLocal(Long memberId, Long postId, List<MultipartFile> images) throws IOException {
+        Post post = findPostByIdOrThrow(postId);
+        if (!post.getMember().getId().equals(memberId)) {
             throw new MyException(MyErrorCode.HAS_NOT_POST_AUTHORIZATION);
         }
-        if(images!=null){
-            for(int i = 1 ; i < post.getImageCount() ; i++){
+        if (images != null) {
+            for (int i = 1; i < post.getImageCount(); i++) {
                 String fileName = postId + "-" + i;
                 Path filePath = Paths.get(path, fileName);
                 Files.deleteIfExists(filePath);
             }
-            for(int i = 1 ; i < images.size()+1;i++){
+            for (int i = 1; i < images.size() + 1; i++) {
                 MultipartFile file = images.get(i - 1);
                 String fileName = postId + "-" + i;
                 Path filePath = Paths.get(path, fileName);
@@ -127,12 +142,11 @@ public class PostService {
 
     @Transactional
     public void delete(Long memberId, Long postId) throws IOException {
-        Post post = postRepository.findById(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(!post.getMember().getId().equals(memberId)){
-            throw new MyException(MyErrorCode.HAS_NOT_POST_AUTHORIZATION);
-        }
-        redisService.deleteImage(postId,post.getImageCount());
-        for(int i = 1 ; i < post.getImageCount()+1;i++){
+        Post post = findPostByIdOrThrow(postId);
+
+        validateMemberAuthorization(post, memberId);
+        redisService.deleteImage(postId, post.getImageCount());
+        for (int i = 1; i < post.getImageCount() + 1; i++) {
             String fileName = postId + "-" + i;
             Path filePath = Paths.get(path, fileName);
             Files.deleteIfExists(filePath);
@@ -141,54 +155,52 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto getPost(Long postId,Member member,String address){
-        Post post = postRepository.findById(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(redisService.isFirstConnect(address,postId)){
-            redisService.insertAddress(address,postId);
+    public PostResponseDto getPost(Long postId, Member member, String address) {
+        Post post = findPostByIdOrThrow(postId);
+        if (redisService.isFirstConnect(address, postId)) {
+            redisService.insertAddress(address, postId);
             post.upViewCount();
         }
         long fireId;
         boolean isLiked = false;
         boolean isScraped = false;
         boolean hasAuthority = false;
-        if(member!=null){
-            if(likePostRepository.existsByMemberAndPost(member,post)){
+        if (member != null) {
+            if (likePostRepository.existsByMemberAndPost(member, post)) {
                 isLiked = true;
             }
-            if(scrapRepository.existsByMemberAndPost(member,post)){
+            if (scrapRepository.existsByMemberAndPost(member, post)) {
                 isScraped = true;
             }
-            if(post.getMember()!=null&&member.getId().equals(post.getMember().getId())){
+            if (post.getMember() != null && member.getId().equals(post.getMember().getId())) {
                 hasAuthority = true;
             }
         }
         String writer;
-        if(post.getMember()==null){
-            writer="(알수없음)";
-            fireId =13;
-        }
-        else{
+        if (post.getMember() == null) {
+            writer = "(알수없음)";
+            fireId = 13;
+        } else {
             fireId = post.getMember().getFireId();
             if (post.getAnonymous()) {
                 writer = "횃불이";
-            }
-            else{
+            } else {
                 writer = post.getMember().getNickname();
             }
         }
-        return  PostResponseDto.of(post,writer,fireId,isLiked,isScraped,hasAuthority,replyService.getReplies(postId,member),replyService.getBestReplies(postId,member));
+        return PostResponseDto.of(post, writer, fireId, isLiked, isScraped, hasAuthority,
+                replyService.getReplies(postId, member), replyService.getBestReplies(postId, member));
     }
 
 
     @Transactional(readOnly = true)
-    public ListResponseDto getAllPost(String category, String sort, int page){
-        Pageable pageable = PageRequest.of(page>0?--page:page,8,sortData(sort));
+    public ListResponseDto getAllPost(String category, String sort, int page) {
+        Pageable pageable = PageRequest.of(page > 0 ? --page : page, 8, sortData(sort));
         Page<Post> dto;
-        if(category==null){
+        if (category == null) {
             dto = postRepository.findAllBy(pageable);
-        }
-        else{
-            if(!categoryRepository.existsByCategory(category)){
+        } else {
+            if (!categoryRepository.existsByCategory(category)) {
                 throw new MyException(MyErrorCode.CATEGORY_NOT_FOUND);
             }
             dto = postRepository.findAllByCategory(category, pageable);
@@ -201,20 +213,20 @@ public class PostService {
         return ListResponseDto.of(pages, total, posts);
     }
 
-
     @Transactional
-    public int likePost(Member member, Long postId){
-        Post post = postRepository.findByIdWithLock(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(post.getMember()!=null&&post.getMember().getId().equals(member.getId())){
+    public int likePost(Member member, Long postId) {
+        Post post = postRepository.findByIdWithLock(postId)
+                .orElseThrow(() -> new MyException(MyErrorCode.POST_NOT_FOUND));
+        if (post.getMember() != null && post.getMember().getId().equals(member.getId())) {
             throw new MyException(MyErrorCode.NOT_LIKE_MY_POST);
         }
-        if(likePostRepository.existsByMemberAndPost(member,post)){
-            PostLike postLike = likePostRepository.findByMemberAndPost(member,post).orElseThrow(()->new MyException(MyErrorCode.USER_OR_POST_NOT_FOUND));
+        if (likePostRepository.existsByMemberAndPost(member, post)) {
+            PostLike postLike = likePostRepository.findByMemberAndPost(member, post)
+                    .orElseThrow(() -> new MyException(MyErrorCode.USER_OR_POST_NOT_FOUND));
             likePostRepository.delete(postLike);
             post.downLike();
             return -1;
-        }
-        else {
+        } else {
             PostLike postLike = PostLike.builder().member(member).post(post).build();
             likePostRepository.save(postLike);
             post.upLike();
@@ -223,15 +235,16 @@ public class PostService {
     }
 
     @Transactional
-    public int scrapPost(Member member, Long postId){
-        Post post = postRepository.findByIdWithLock(postId).orElseThrow(()->new MyException(MyErrorCode.POST_NOT_FOUND));
-        if(scrapRepository.existsByMemberAndPost(member,post)){
-            Scrap scrap = scrapRepository.findByMemberAndPost(member,post).orElseThrow(()->new MyException(MyErrorCode.USER_OR_POST_NOT_FOUND));
+    public int scrapPost(Member member, Long postId) {
+        Post post = postRepository.findByIdWithLock(postId)
+                .orElseThrow(() -> new MyException(MyErrorCode.POST_NOT_FOUND));
+        if (scrapRepository.existsByMemberAndPost(member, post)) {
+            Scrap scrap = scrapRepository.findByMemberAndPost(member, post)
+                    .orElseThrow(() -> new MyException(MyErrorCode.USER_OR_POST_NOT_FOUND));
             scrapRepository.delete(scrap);
             post.downScrap();
             return -1;
-        }
-        else{
+        } else {
             Scrap scrap = Scrap.builder().member(member).post(post).build();
             scrapRepository.save(scrap);
             post.upScrap();
@@ -240,26 +253,26 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostListResponseDto> getPostByMember(Member member, String sort){
-        return postRepository.findAllByMember(member,sortData(sort))
+    public List<PostListResponseDto> getPostByMember(Member member, String sort) {
+        return postRepository.findAllByMember(member, sortData(sort))
                 .stream()
                 .map(this::getPostListResponseDto)
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public ListResponseDto getScrapsByMember(Member member, String sort,int page){
+    public ListResponseDto getScrapsByMember(Member member, String sort, int page) {
         List<PostListResponseDto> scraps = scrapRepository.findAllByMember(member, sortFetchJoin(sort)).stream()
                 .map(scrap -> {
                     Post post = scrap.getPost();
                     return getPostListResponseDto(post);
                 })
                 .collect(Collectors.toList());
-        return pagingFetchJoin(page,scraps);
+        return pagingFetchJoin(page, scraps);
     }
 
     @Transactional(readOnly = true)
-    public List<PostListResponseDto> getLikeByMember(Member member, String sort){
+    public List<PostListResponseDto> getLikeByMember(Member member, String sort) {
         return likePostRepository.findAllByMember(member, sortFetchJoin(sort)).stream()
                 .map(like -> {
                     Post post = like.getPost();
@@ -268,125 +281,119 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-
-
     public PostListResponseDto getPostListResponseDto(Post post) {
         String writer;
-        if(post.getMember()==null){
-            writer="(알수없음)";
-        }
-        else{
+        if (post.getMember() == null) {
+            writer = "(알수없음)";
+        } else {
             if (post.getAnonymous()) {
                 writer = "횃불이";
-            }
-            else{
+            } else {
                 writer = memberRepository.findById(post.getMember().getId()).get().getNickname();
             }
         }
-        return PostListResponseDto.of(post,writer);
+        return PostListResponseDto.of(post, writer);
     }
 
     @Transactional(readOnly = true)
-    public ListResponseDto searchPost(String query,String sort,int page){
-        Pageable pageable = PageRequest.of(page>0?--page:page,8);
+    public ListResponseDto searchPost(String query, String sort, int page) {
+        Pageable pageable = PageRequest.of(page > 0 ? --page : page, 8);
         if (sort.equals("date")) {
-            Page<Post> dto = postRepository.searchByKeyword(query,pageable);
-            return ListResponseDto.of(dto.getTotalPages(),dto.getTotalElements(),dto.stream().map(this::getPostListResponseDto).collect(Collectors.toList()));
+            Page<Post> dto = postRepository.searchByKeyword(query, pageable);
+            return ListResponseDto.of(dto.getTotalPages(), dto.getTotalElements(),
+                    dto.stream().map(this::getPostListResponseDto).collect(Collectors.toList()));
         } else if (sort.equals("like")) {
-            Page<Post> dto = postRepository.searchByKeywordOrderByLikes(query,pageable);
-            return ListResponseDto.of(dto.getTotalPages(), dto.getTotalElements(), dto.stream().map(this::getPostListResponseDto).collect(Collectors.toList()));
+            Page<Post> dto = postRepository.searchByKeywordOrderByLikes(query, pageable);
+            return ListResponseDto.of(dto.getTotalPages(), dto.getTotalElements(),
+                    dto.stream().map(this::getPostListResponseDto).collect(Collectors.toList()));
         } else if (sort.equals("scrap")) {
-            Page<Post> dto = postRepository.searchByKeywordOrderByScraps(query,pageable);
-            return ListResponseDto.of(dto.getTotalPages(), dto.getTotalElements(),dto.stream().map(this::getPostListResponseDto).collect(Collectors.toList()));
+            Page<Post> dto = postRepository.searchByKeywordOrderByScraps(query, pageable);
+            return ListResponseDto.of(dto.getTotalPages(), dto.getTotalElements(),
+                    dto.stream().map(this::getPostListResponseDto).collect(Collectors.toList()));
         } else {
             throw new MyException(MyErrorCode.WRONG_SORT_TYPE);
         }
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = "topPost", key = "#category != null ? #category : 'default'",cacheManager = "cacheManager")
-    public List<PostListResponseDto> getTop(String category){
-        return postRepository.findTop12(category).stream().map(this::getPostListResponseDto).collect(Collectors.toList());
+    @Cacheable(value = "topPost", key = "#category != null ? #category : 'default'", cacheManager = "cacheManager")
+    public List<PostListResponseDto> getTop(String category) {
+        return postRepository.findTop12(category).stream().map(this::getPostListResponseDto)
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     @Cacheable(value = "randomPost", cacheManager = "cacheManager")
-    public List<PostListResponseDto> getRandomTop(){
+    public List<PostListResponseDto> getRandomTop() {
         return postRepository.findRandomTop().stream().map(this::getPostListResponseDto).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public ListResponseDto searchInScrap(Member member, String query,int page, String sort){
-        List<PostListResponseDto> scraps  = scrapRepository.searchScrap(member,query, sortFetchJoin(sort)).stream()
+    public ListResponseDto searchInScrap(Member member, String query, int page, String sort) {
+        List<PostListResponseDto> scraps = scrapRepository.searchScrap(member, query, sortFetchJoin(sort)).stream()
                 .map(scrap -> {
                     Post post = scrap.getPost();
                     return getPostListResponseDto(post);
                 })
                 .collect(Collectors.toList());
-        return pagingFetchJoin(page,scraps);
+        return pagingFetchJoin(page, scraps);
     }
 
 
     @Transactional(readOnly = true)
-    public List<PostListResponseDto> getPostForInf(Long lastPostId,String category){
-        Pageable pageable = PageRequest.of(0,8,sortData("date"));
-        if(lastPostId==null&&category==null){
-            return postRepository.findAll(pageable).stream().map(this::getPostListResponseDto).collect(Collectors.toList());
-        }
-        else if(lastPostId == null){
-            return postRepository.findAllByCategory(category,pageable).stream().map(this::getPostListResponseDto).collect(Collectors.toList());
-        }
-        else if(category!=null){
-           return postRepository.findByCategoryAndIdLessThan(category,lastPostId,pageable).stream().map(this::getPostListResponseDto).collect(Collectors.toList());
-        }
-        else {
-            return postRepository.findAllByIdLessThan(lastPostId, pageable).stream().map(this::getPostListResponseDto).collect(Collectors.toList());
+    public List<PostListResponseDto> getPostForInf(Long lastPostId, String category) {
+        Pageable pageable = PageRequest.of(0, 8, sortData("date"));
+        if (lastPostId == null && category == null) {
+            return postRepository.findAll(pageable).stream().map(this::getPostListResponseDto)
+                    .collect(Collectors.toList());
+        } else if (lastPostId == null) {
+            return postRepository.findAllByCategory(category, pageable).stream().map(this::getPostListResponseDto)
+                    .collect(Collectors.toList());
+        } else if (category != null) {
+            return postRepository.findByCategoryAndIdLessThan(category, lastPostId, pageable).stream()
+                    .map(this::getPostListResponseDto).collect(Collectors.toList());
+        } else {
+            return postRepository.findAllByIdLessThan(lastPostId, pageable).stream().map(this::getPostListResponseDto)
+                    .collect(Collectors.toList());
         }
     }
 
-    public ListResponseDto pagingFetchJoin(int page, List<PostListResponseDto> dto){
+    public ListResponseDto pagingFetchJoin(int page, List<PostListResponseDto> dto) {
         int total = dto.size();
         page--;
         int startIndex = 0;
         int endIndex = 0;
-        long pages = (long)Math.ceil( (double) dto.size() /5);
-        if(page*5>dto.size()){
+        long pages = (long) Math.ceil((double) dto.size() / 5);
+        if (page * 5 > dto.size()) {
             dto.clear();
+        } else {
+            startIndex = page * 5;
+            endIndex = Math.min((page + 1) * 5, dto.size());
         }
-        else{
-            startIndex = page*5;
-            endIndex  = Math.min((page + 1) * 5, dto.size());
-        }
-        return  ListResponseDto.of(pages,total,dto.subList(startIndex,endIndex));
+        return ListResponseDto.of(pages, total, dto.subList(startIndex, endIndex));
     }
 
-    public Sort sortFetchJoin(String sort){
-        if(sort.equals("date")){
+    public Sort sortFetchJoin(String sort) {
+        if (sort.equals("date")) {
             return Sort.by(Sort.Direction.DESC, "post.id");
-        }
-        else if(sort.equals("like")){
-            return Sort.by(Sort.Direction.DESC, "post.good","post.id");
-        }
-        else if(sort.equals("scrap")){
-            return Sort.by(Sort.Direction.DESC, "post.scrap","post.id");
-        }
-        else{
-            throw new MyException(MyErrorCode.WRONG_SORT_TYPE);
-        }
-    }
-    public Sort sortData(String sort){
-        if(sort.equals("date")){
-            return Sort.by(Sort.Direction.DESC, "id");
-        }
-        else if(sort.equals("like")){
-            return Sort.by(Sort.Direction.DESC, "good","id");
-        }
-        else if(sort.equals("scrap")){
-            return Sort.by(Sort.Direction.DESC, "scrap","id");
-        }
-        else{
+        } else if (sort.equals("like")) {
+            return Sort.by(Sort.Direction.DESC, "post.good", "post.id");
+        } else if (sort.equals("scrap")) {
+            return Sort.by(Sort.Direction.DESC, "post.scrap", "post.id");
+        } else {
             throw new MyException(MyErrorCode.WRONG_SORT_TYPE);
         }
     }
 
+    public Sort sortData(String sort) {
+        if (sort.equals("date")) {
+            return Sort.by(Sort.Direction.DESC, "id");
+        } else if (sort.equals("like")) {
+            return Sort.by(Sort.Direction.DESC, "good", "id");
+        } else if (sort.equals("scrap")) {
+            return Sort.by(Sort.Direction.DESC, "scrap", "id");
+        } else {
+            throw new MyException(MyErrorCode.WRONG_SORT_TYPE);
+        }
+    }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
 
     @Transactional
     public Long saveOnlyPost(Member member, PostDto postSaveDto) throws NoSuchAlgorithmException {
-        validateCategory(postSaveDto);
+        validateCategory(postSaveDto.getCategory());
         String hash = postSaveDto.getTitle() + postSaveDto.getContent();
         redisService.blockRepeat(hash);
         Post post = Post.builder()
@@ -64,7 +64,7 @@ public class PostService {
     @Transactional
     public void updateOnlyPost(Long memberId, Long postId, PostDto postDto) {
         Post post = postCommonService.findPostByIdOrThrow(postId);
-        validateCategory(postDto);
+        validateCategory(postDto.getCategory());
         postCommonService.validateMemberAuthorization(post, memberId);
         post.updateOnlyPost(postDto.getTitle(), postDto.getContent(), postDto.getCategory(), postDto.getAnonymous());
     }
@@ -78,8 +78,8 @@ public class PostService {
         postRepository.delete(post);
     }
 
-    private void validateCategory(PostDto postSaveDto) {
-        if (!categoryRepository.existsByCategory(postSaveDto.getCategory())) {
+    private void validateCategory(String category) {
+        if (!categoryRepository.existsByCategory(category)) {
             throw new MyException(MyErrorCode.CATEGORY_NOT_FOUND);
         }
     }
@@ -129,9 +129,7 @@ public class PostService {
         if (category == null) {
             dto = postRepository.findAllBy(pageable);
         } else {
-            if (!categoryRepository.existsByCategory(category)) {
-                throw new MyException(MyErrorCode.CATEGORY_NOT_FOUND);
-            }
+            validateCategory(category);
             dto = postRepository.findAllByCategory(category, pageable);
         }
         long total = dto.getTotalElements();


### PR DESCRIPTION
1. PostService의 중복된 로직을 제거하고 메서드로 추출하여 코드 가독성 및 유지보수성을 개선했습니다.
2. PostService에 코드가 너무 많아 이미지 관련 코드는 PostImageService로 분리시키고 가독성이 좋도록 메소드 위치들을 변경하였습니다.
3. PostService와 PostImageService 간 순환 참조 문제를 해결하기 위해 PostCommonService를 도입하여 공통 로직을 관리하도록 했습니다.