### PR TITLE
test : folder 도메인 서비스  단위 테스트 코드 일부 추가 

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+inu-portal

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/MySqlConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/MySqlConfig.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 @Configuration
 @EnableTransactionManagement
-@EnableJpaRepositories(basePackages = {"kr.inuappcenterportal.inuportal.repository"})
+@EnableJpaRepositories(basePackages = {"kr.inuappcenterportal.inuportal.domain"})
 public class MySqlConfig {
     @Bean(name = "dataSource")
     @Primary

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyException.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyException.java
@@ -7,6 +7,7 @@ public class MyException extends RuntimeException{
     private MyErrorCode errorCode;
 
     public MyException(MyErrorCode errorCode){
+        super(errorCode.getMessage()); // 부모 RuntimeException에 메시지 전달
         this.errorCode = errorCode;
     }
 }

--- a/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
@@ -1,0 +1,107 @@
+package kr.inuappcenterportal.inuportal.domain.folder.service;
+
+import kr.inuappcenterportal.inuportal.domain.folder.dto.FolderDto;
+import kr.inuappcenterportal.inuportal.domain.folder.model.Folder;
+import kr.inuappcenterportal.inuportal.domain.folder.repository.FolderRepository;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FolderServiceTest {
+    @Mock
+    private FolderRepository folderRepository;
+
+    @Mock
+    private Member member;
+
+    @InjectMocks
+    private FolderService folderService;
+
+    private Folder folder;
+    private FolderDto folderDto;
+
+
+    @Transactional
+    public Long createFolder(Member member, FolderDto folderDto ){
+        return folderRepository.save(Folder.builder().name(folderDto.getName()).member(member).build()).getId();
+    }
+
+    @Transactional
+    public Long updateFolder(Long folderId, FolderDto folderDto){
+        Folder folder = folderRepository.findById(folderId).orElseThrow(()->new MyException(MyErrorCode.FOLDER_NOT_FOUND));
+        folder.update(folderDto.getName());
+        return folderId;
+    }
+
+    @BeforeEach
+    void setUp() {
+        member = new Member("20231001", "member1", List.of("ROLE_USER"));
+        folderDto = new FolderDto("테스트 폴더1");
+        folder = Folder.builder().name("테스트 폴더1").member(member).build();
+//        folder.setId(1L);
+        ReflectionTestUtils.setField(folder, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("스크랩 폴더 생성 테스트")
+    void createFolder() {
+        //given : createFolder메서드에서 실행되는 folderRepository.save()가 호출되면, 미리 준비된 folder 객체를 반환
+        when(folderRepository.save(any(Folder.class))).thenReturn(folder);
+
+        //when
+        Long folderId = folderService.createFolder(member, folderDto);
+
+        //then
+        assertThat(folderId).isEqualTo(1L);
+        verify(folderRepository, times(1)).save(any(Folder.class));
+    }
+
+    @Test
+    @DisplayName("스크랩 폴더명 수정 테스트")
+    void updateFolder() {
+        FolderDto updateDto = new FolderDto("폴더명 수정1");
+
+        // given: updateFolder메서드가 실행되면 findById를 통해 id가 존재하는지 1차 체크를 한다
+        when(folderRepository.findById(1L)).thenReturn(Optional.of(folder));
+
+        // when: updateFolder 메서드 호출
+        Long updatedFolderId = folderService.updateFolder(1L, updateDto);
+
+        // then: 폴더 ID와 폴더 이름이 올바르게 업데이트되었는지 검증
+        assertThat(updatedFolderId).isEqualTo(1L);
+        assertThat(folder.getName()).isEqualTo("폴더명 수정1");
+        verify(folderRepository, times(1)).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("updateFolder메서드 실행중에 폴더id를 찾을 수 없는 경우 테스트")
+    void updateFolder_FolderNotFound() {
+        // given: findById 메서드에서 폴더를 찾지못한 경우 가정
+        when(folderRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then: 예외가 발생하는지 검증
+        assertThatThrownBy(() -> folderService.updateFolder(1L, folderDto))
+                .isInstanceOf(MyException.class) // 던져진 예외가 MyException 타입인지 확인
+                .hasMessageContaining(MyErrorCode.FOLDER_NOT_FOUND.getMessage());
+
+        // folderRepository의 findById가 한 번 호출되었는지 검증
+        verify(folderRepository, times(1)).findById(anyLong());
+    }
+}

--- a/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
@@ -1,9 +1,18 @@
 package kr.inuappcenterportal.inuportal.domain.folder.service;
 
 import kr.inuappcenterportal.inuportal.domain.folder.dto.FolderDto;
+import kr.inuappcenterportal.inuportal.domain.folder.dto.FolderPostDto;
+import kr.inuappcenterportal.inuportal.domain.folder.dto.FolderResponseDto;
 import kr.inuappcenterportal.inuportal.domain.folder.model.Folder;
 import kr.inuappcenterportal.inuportal.domain.folder.repository.FolderRepository;
+import kr.inuappcenterportal.inuportal.domain.folderPost.model.FolderPost;
+import kr.inuappcenterportal.inuportal.domain.folderPost.repository.FolderPostRepository;
 import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.member.repository.MemberRepository;
+import kr.inuappcenterportal.inuportal.domain.post.model.Post;
+import kr.inuappcenterportal.inuportal.domain.post.repository.PostRepository;
+import kr.inuappcenterportal.inuportal.domain.scrap.model.Scrap;
+import kr.inuappcenterportal.inuportal.domain.scrap.repository.ScrapRepository;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,17 +35,30 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class FolderServiceTest {
+
     @Mock
     private FolderRepository folderRepository;
 
     @Mock
-    private Member member;
+    private FolderPostRepository folderPostRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private ScrapRepository scrapRepository;
 
     @InjectMocks
     private FolderService folderService;
 
     private Folder folder;
     private FolderDto folderDto;
+    private Post post;
+    private Scrap scrap;
+    private Member member;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +67,14 @@ class FolderServiceTest {
         folder = Folder.builder().name("테스트 폴더1").member(member).build();
 //        folder.setId(1L);
         ReflectionTestUtils.setField(folder, "id", 1L);
+
+        // Post 객체 초기화
+        post = Post.builder().title("Test Post").content("Content").build();
+        ReflectionTestUtils.setField(post, "id", 1L);
+
+        // Scrap 객체 초기화
+        scrap = Scrap.builder().member(member).post(post).build();
+        ReflectionTestUtils.setField(scrap, "id", 1L);
     }
 
     @Test
@@ -122,5 +152,76 @@ class FolderServiceTest {
     }
 
 
+    // insertInFolder은 내부 로직이 많아서 테스트 메서드를 분류함
+    @Test
+    @DisplayName("폴더에 게시물 추가 성공 - 지정된 폴더에 게시물을 정상적으로 추가하고 ID를 반환합니다.")
+    void insertInFolder_Success() {
+        // given : FolderPostDto는 postId를 리스트로 담아서 가져오고 테스트에서는 1 이 담겨 있다고 가정
+        FolderPostDto folderPostDto = new FolderPostDto(List.of(1L));
 
+        // id가 1인 폴더가 존재한다고 가정
+        given(folderRepository.findById(1L)).willReturn(Optional.of(folder));
+        // 폴더에 연결된 멤버가 있다고 가정
+        given(memberRepository.findById(folder.getMember().getId())).willReturn(Optional.of(member));
+
+        // for문 안의 로직 : folderPostDto로 받아온 리스트 id를 통해 동작
+        // 게시물(post) ID가 1L인 게시물이 존재한다고 가정.
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+        // 멤버와 게시물 간의 스크랩 데이터가 존재한다고 가정
+        given(scrapRepository.findByMemberAndPost(member, post)).willReturn(Optional.of(scrap));
+        // 폴더에 이미 해당 게시물이 존재하지 않는다고 가정
+        given(folderPostRepository.existsByFolderAndPost(folder, post)).willReturn(false);
+
+        // when
+        Long folderId = folderService.insertInFolder(1L, folderPostDto);
+
+        // then
+        assertThat(folderId).isEqualTo(1L);
+        verify(folderPostRepository, times(1)).save(any(FolderPost.class));
+    }
+    @Test
+    @DisplayName("폴더에 게시물 추가 실패 - 존재하지 않는 폴더로 인해 추가할 수 없습니다.")
+    void insertInFolder_FolderNotFound() {
+        // given
+        FolderPostDto folderPostDto = new FolderPostDto(List.of(1L));
+        given(folderRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> folderService.insertInFolder(1L, folderPostDto))
+                .isInstanceOf(MyException.class)
+                .hasMessageContaining(MyErrorCode.FOLDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("폴더에 게시물 추가 실패 - 폴더에 추가하려는 게시물을 찾을 수 없습니다.")
+    void insertInFolder_PostNotFound() {
+        // given
+        FolderPostDto folderPostDto = new FolderPostDto(List.of(1L));
+        given(folderRepository.findById(1L)).willReturn(Optional.of(folder));
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+        given(postRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> folderService.insertInFolder(1L, folderPostDto))
+                .isInstanceOf(MyException.class)
+                .hasMessageContaining(MyErrorCode.POST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("폴더에 게시물 추가 실패 - 이미 폴더에 존재하는 중복된 게시물입니다.")
+    void insertInFolder_DuplicatePost() {
+        // given
+        FolderPostDto folderPostDto = new FolderPostDto(List.of(1L));
+        given(folderRepository.findById(1L)).willReturn(Optional.of(folder));
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+        given(scrapRepository.findByMemberAndPost(member, post)).willReturn(Optional.of(scrap));
+        given(folderPostRepository.existsByFolderAndPost(folder, post)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> folderService.insertInFolder(1L, folderPostDto))
+                .isInstanceOf(MyException.class)
+                .hasMessageContaining(MyErrorCode.POST_DUPLICATE_FOLDER.getMessage());
+    }
+    
 }

--- a/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
@@ -93,6 +93,34 @@ class FolderServiceTest {
         verify(folderRepository, times(1)).findById(anyLong());
     }
 
+   @Test
+   @DisplayName("존재하는 폴더 ID로 삭제 요청 시 폴더가 삭제된다")
+   void deleteFolder_Success() {
+       // given
+       given(folderRepository.findById(1L)).willReturn(Optional.of(folder));
+
+       // when: deleteFolder 메서드 호출
+       folderService.deleteFolder(1L);
+
+       // then: 폴더가 삭제되었는지 확인
+       verify(folderRepository, times(1)).delete(folder);
+   }
+
+    @Test
+    @DisplayName("존재하지 않는 폴더 ID로 삭제 요청 시 MyException이 발생한다")
+    void deleteFolder_FolderNotFound() {
+        // given: 폴더 ID로 폴더를 찾을 수 없는 경우
+        given(folderRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then: MyException 발생 여부 확인
+        assertThatThrownBy(() -> folderService.deleteFolder(1L))
+                .isInstanceOf(MyException.class)
+                .hasMessageContaining(MyErrorCode.FOLDER_NOT_FOUND.getMessage());
+
+        // then: delete 메서드가 호출되지 않았음을 검증
+        verify(folderRepository, never()).delete(any(Folder.class));
+    }
+
 
 
 }

--- a/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -103,9 +104,11 @@ class FolderServiceTest {
         Long updatedFolderId = folderService.updateFolder(1L, updateDto);
 
         // then: 폴더 ID와 폴더 이름이 올바르게 업데이트되었는지 검증
-        assertThat(updatedFolderId).isEqualTo(1L);
-        assertThat(folder.getName()).isEqualTo("폴더명 수정1");
-        verify(folderRepository, times(1)).findById(anyLong());
+        assertAll(
+                () -> assertThat(updatedFolderId).isEqualTo(1L),
+                () -> assertThat(folder.getName()).isEqualTo("폴더명 수정1"),
+                () -> verify(folderRepository, times(1)).findById(anyLong())
+        );
     }
 
     @Test

--- a/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/domain/folder/service/FolderServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,19 +38,6 @@ class FolderServiceTest {
     private Folder folder;
     private FolderDto folderDto;
 
-
-    @Transactional
-    public Long createFolder(Member member, FolderDto folderDto ){
-        return folderRepository.save(Folder.builder().name(folderDto.getName()).member(member).build()).getId();
-    }
-
-    @Transactional
-    public Long updateFolder(Long folderId, FolderDto folderDto){
-        Folder folder = folderRepository.findById(folderId).orElseThrow(()->new MyException(MyErrorCode.FOLDER_NOT_FOUND));
-        folder.update(folderDto.getName());
-        return folderId;
-    }
-
     @BeforeEach
     void setUp() {
         member = new Member("20231001", "member1", List.of("ROLE_USER"));
@@ -60,10 +48,10 @@ class FolderServiceTest {
     }
 
     @Test
-    @DisplayName("스크랩 폴더 생성 테스트")
+    @DisplayName("스크랩 폴더를 생성하면 생성된 폴더의 ID를 반환한다")
     void createFolder() {
         //given : createFolder메서드에서 실행되는 folderRepository.save()가 호출되면, 미리 준비된 folder 객체를 반환
-        when(folderRepository.save(any(Folder.class))).thenReturn(folder);
+        given(folderRepository.save(any(Folder.class))).willReturn(folder);
 
         //when
         Long folderId = folderService.createFolder(member, folderDto);
@@ -74,12 +62,12 @@ class FolderServiceTest {
     }
 
     @Test
-    @DisplayName("스크랩 폴더명 수정 테스트")
+    @DisplayName("존재하는 스크랩 폴더의 이름을 수정하면 수정된 폴더의 ID를 반환한다")
     void updateFolder() {
         FolderDto updateDto = new FolderDto("폴더명 수정1");
 
         // given: updateFolder메서드가 실행되면 findById를 통해 id가 존재하는지 1차 체크를 한다
-        when(folderRepository.findById(1L)).thenReturn(Optional.of(folder));
+        given(folderRepository.findById(1L)).willReturn(Optional.of(folder));
 
         // when: updateFolder 메서드 호출
         Long updatedFolderId = folderService.updateFolder(1L, updateDto);
@@ -91,10 +79,10 @@ class FolderServiceTest {
     }
 
     @Test
-    @DisplayName("updateFolder메서드 실행중에 폴더id를 찾을 수 없는 경우 테스트")
+    @DisplayName("폴더 수정 시 존재하지 않는 폴더 ID를 입력하면 MyException이 발생한다")
     void updateFolder_FolderNotFound() {
         // given: findById 메서드에서 폴더를 찾지못한 경우 가정
-        when(folderRepository.findById(anyLong())).thenReturn(Optional.empty());
+        given(folderRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when & then: 예외가 발생하는지 검증
         assertThatThrownBy(() -> folderService.updateFolder(1L, folderDto))
@@ -104,4 +92,7 @@ class FolderServiceTest {
         // folderRepository의 findById가 한 번 호출되었는지 검증
         verify(folderRepository, times(1)).findById(anyLong());
     }
+
+
+
 }


### PR DESCRIPTION
## 📋 이슈 번호
#11
## 🛠 구현 사항
- folder 서비스 메서드에 대한 테스트 코드 작성 
- createFolder
- updateFolder
- deleteFolder
- insertInFolder    
- getFolder
## 📚 기타 
테스트 코드를 위해 생성한 객체에 setId 메서드 사용 불가로  id를 강제로 주입하기 위해 Reflection 사용 
-승진님 문구를 참고해 DisplayName 수정 
-folder 도메인 경우 특정 서비스 코드는 member,folderPost,scrap 이 섞인 복잡한 로직이라 
-단위 테스트 코드가 길어짐 - > 현재는 단위테스트 시도를 했고 추후에 통합 테스트 코드도 작성할 예정 
[질문]
구글링과 gpt,유튜브 조합해서 테스트 코드를 작성하긴 했는데 작업한 내용의 문제점은 없는지, 작성 방법이나 이상한 부분은 없는지 궁금합니다 

  
[질문]