### PR TITLE
feat: 오류 모니터링 - Sentry 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
     id "io.sentry.jvm.gradle" version "4.14.1"
@@ -14,6 +15,10 @@ java {
 
 repositories {
     mavenCentral()
+}
+
+jacoco {
+    toolVersion = "0.8.10"
 }
 
 
@@ -48,8 +53,38 @@ dependencies {
     implementation 'com.oracle.database.jdbc:ojdbc11'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator' // Spring Actuator
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus' // Prometheus
+
 }
+
+// 제외할 디렉토리 및 파일 패턴을 공통 변수로 선언
+ext.jacocoExcludes = [
+        "**/generated/**", // Querydsl Qfile
+        "**/dto/**",       // DTO 클래스
+        "**/exception/**", // 커스텀 예외
+        "**/config/**",    // 설정 파일
+]
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn(tasks.named('test')) // 테스트 실행 후 리포트 생성
+    reports {
+        xml.required = true // SonarQube를 위한 XML 리포트 생성
+        html.required = true // 사람이 읽기 쉬운 HTML 리포트 생성
+        csv.required = false // CSV 리포트는 비활성화
+    }
+    classDirectories.setFrom(
+            files(classDirectories.files.collect { dir ->
+                fileTree(dir) {
+                    exclude jacocoExcludes // 리포트 생성에서 제외할 디렉토리와 파일 설정
+                }
+            })
+    )
+
+    // finalizedBy tasks.named('jacocoTestCoverageVerification') // 리포트 생성 후 검증
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
+    id "io.sentry.jvm.gradle" version "4.14.1"
 }
 
 group = 'kr.inu-appcenter-portal'
@@ -14,6 +15,7 @@ java {
 repositories {
     mavenCentral()
 }
+
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'


### PR DESCRIPTION
에러 모니터링 기능 추가는 코드 한 줄 딸깍이 끝입니다.
  Sentry 홈페이지에서 회원가입하시면 조직에 초대해드릴게요. 
해당 사이트에서 에러에 대한 모니터링, api 트래픽 통계, api 호출 시간 등의 성능 관련 부분도 체크 가능합니다. 
자세한 내용은 노션 데일리 일지에 작성되어 있습니다.
